### PR TITLE
Changed Link to avoid console error

### DIFF
--- a/src/components/PetCard.jsx
+++ b/src/components/PetCard.jsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Card,
   CardContent,
   CardFooter,

--- a/src/components/PetCard.jsx
+++ b/src/components/PetCard.jsx
@@ -1,22 +1,23 @@
 import {
+  Button,
   Card,
   CardContent,
   CardFooter,
-  Button
 } from "@baltimorecounty/dotgov-components";
-import PetAttributeRows from "./PetAttributeRows";
+
 import { Link } from "react-router-dom";
+import PetAttributeRows from "./PetAttributeRows";
 import PetThumbnail from "./PetThumbnail";
 import React from "react";
 
-const PetCard = props => {
+const PetCard = (props) => {
   const {
     imageUrl,
     imageUrlAltText,
     animalName,
     animalId,
     attributes,
-    url
+    url,
   } = props;
 
   return (
@@ -36,8 +37,8 @@ const PetCard = props => {
         </div>
       </CardContent>
       <CardFooter className="text-right">
-        <Link to={`/pets/${animalId}`}>
-          <Button as="a" text="Details" href={url} />
+        <Link className="dg_button" to={`/pets/${animalId}`}>
+          Details
         </Link>
       </CardFooter>
     </Card>

--- a/src/components/PetCard.jsx
+++ b/src/components/PetCard.jsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Card,
   CardContent,
   CardFooter,
@@ -11,14 +10,7 @@ import PetThumbnail from "./PetThumbnail";
 import React from "react";
 
 const PetCard = (props) => {
-  const {
-    imageUrl,
-    imageUrlAltText,
-    animalName,
-    animalId,
-    attributes,
-    url,
-  } = props;
+  const { imageUrl, imageUrlAltText, animalName, animalId, attributes } = props;
 
   return (
     <Card className="text-left">


### PR DESCRIPTION
React was throwing an error saying a button couldn't be nested inside of a link. We have "links  buttons" available in [css](https://baltimorecounty.github.io/dotgov-components/#secondary-button-as-link), so this converts this to use css instead of the actually element, avoiding the console error.