### PR TITLE
Temporary Status Fix for Pet Details

### DIFF
--- a/src/hooks/usePet.js
+++ b/src/hooks/usePet.js
@@ -2,13 +2,13 @@ import { useEffect, useState } from "react";
 
 import { GetPet } from "../services/ApiService";
 
-const usePet = (animalId) => {
+const usePet = (animalId, status) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [animal, setAnimal] = useState();
 
   useEffect(() => {
-    GetPet(animalId)
+    GetPet(animalId, status)
       .then((animal) => {
         setAnimal(animal);
       })
@@ -18,7 +18,7 @@ const usePet = (animalId) => {
       .finally(() => {
         setIsLoading(false);
       });
-  }, [animalId]);
+  }, [animalId, status]);
 
   return [
     {

--- a/src/pages/Pet.jsx
+++ b/src/pages/Pet.jsx
@@ -6,7 +6,10 @@ import usePet from "../hooks/usePet";
 
 const AdoptablePetsDetails = (props) => {
   const { animalId } = props.match.params;
-  const [{ hasError, animal, isLoading }] = usePet(animalId);
+  const [{ hasError, animal, isLoading }] = usePet(
+    animalId,
+    window.pets.petStatus
+  );
 
   if (!animal) {
     return <p>Loading information for {animalId}...</p>;

--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -34,7 +34,9 @@ const GetPets = (
  * @param {object} object
  * @param {object} object.animalId unique id for a given animal
  */
-const GetPet = (animalId) =>
-  axios.get(`${getValue("apiRoot")}/${animalId}`).then((resp) => resp.data);
+const GetPet = (animalId, status) =>
+  axios
+    .get(`${getValue("apiRoot")}/${animalId}?status=${status}`)
+    .then((resp) => resp.data);
 
 export { GetStatus, GetPets, GetPet };


### PR DESCRIPTION
As noticed in the demo yesterday duplicated attributes showed up on the details page. This is a bug with the API. 

However, if you pass status to the API, this bug is avoided. Pushing this code to rectify for the demo. A corresponding bug will be logged and fixed in the API, with the hopes that no status will be required.