### PR TITLE
Fix responsive layout on pet details

### DIFF
--- a/src/components/PetDetail.jsx
+++ b/src/components/PetDetail.jsx
@@ -17,10 +17,10 @@ const PetDetail = (props) => {
     <div className="container">
       <h2>{animalName}</h2>
       <div className="row">
-        <div className="col-lg-8 col-md-4 col-xs-12">
+        <div className="col-md-8 col-xs-12">
           <p>{aboutMe}</p>
         </div>
-        <div className="col-lg-4 col-md-4 col-xs-12">
+        <div className="col-md-4 col-xs-12">
           <PetThumbnail
             thumbnail={imageUrl}
             thumbnailAltText={imageUrlAltText}
@@ -28,7 +28,7 @@ const PetDetail = (props) => {
         </div>
       </div>
       <div className="row">
-        <div className="col-lg-12 col-md-8 col-xs-12">
+        <div className="col">
           <PetAttributeRows
             attributes={attributes}
             animalId={animalId}


### PR DESCRIPTION
Detail Layout was not responding properly on smaller screens.

![image](https://user-images.githubusercontent.com/1933400/79235976-4fc90b00-7e3a-11ea-95cf-e6e8d266d057.png)

This pr adjusts the bootstrap classes to ensure the content fills up the empty space in the screen shot.