### PR TITLE
Added regex to fix ie11 date error

### DIFF
--- a/src/utilities/DateFunctions.js
+++ b/src/utilities/DateFunctions.js
@@ -5,5 +5,11 @@ export const FormatDate = (date) => {
     day: "numeric",
   };
 
-  return new Date(date).toLocaleDateString("en-US", options);
+  return (
+    new Date(date)
+      //Added this regex to handle ie11 error
+      //https://stackoverflow.com/questions/21413757/tolocaledatestring-changes-in-ie11/26977768#26977768
+      .toLocaleDateString("en-US", options)
+      .replace(/[^ -~]/g, "")
+  );
 };


### PR DESCRIPTION
https://stackoverflow.com/questions/21413757/tolocaledatestring-changes-in-ie11/26977768#26977768

This regex fixes an issue with ie11 that displays "invalid" date.