### PR TITLE
Fix Pet Details Persisting Scroll Position

### DIFF
--- a/src/components/PetAttributes.jsx
+++ b/src/components/PetAttributes.jsx
@@ -1,10 +1,12 @@
-import React from "react";
 import {
   TableCell,
   TableHeadCell,
   TableRow,
 } from "@baltimorecounty/dotgov-components";
+
 import { ConvertToFriendlyNames } from "../utilities/ConvertToFriendlyNames";
+import React from "react";
+
 const PetAttributes = (props) => {
   const { attributes } = props;
 
@@ -18,29 +20,42 @@ const PetAttributes = (props) => {
   ];
 
   const PetAttributeRows = attributes
-    .filter((attribute) => displayAttributes.includes(attribute.label))
-    .map((item, index) => (
-      <TableRow key={index}>
-        <TableHeadCell>{ConvertToFriendlyNames(item.label)}</TableHeadCell>
-        {item.label === "Age" ? (
-          <TableCell>
-            <span>
-              {item.value}{" "}
-              {attributes.find((x) => x.label === "Age Unit").value}
-            </span>
-          </TableCell>
-        ) : item.label === "Weight" ? (
-          <TableCell>
-            <span>
-              {item.value}
-              {attributes.find((x) => x.label === "Weight Unit").value}
-            </span>
-          </TableCell>
-        ) : (
-          <TableCell>{item.value} </TableCell>
-        )}
-      </TableRow>
-    ));
+    .filter(
+      (attribute) =>
+        displayAttributes.includes(attribute.label) && attribute.value
+    )
+    .map((item, index) => {
+      const { value: weight = "" } = attributes.find(
+        (x) => x.label === "Weight Unit"
+      );
+      const { value: age = "" } = attributes.find(
+        (x) => x.label === "Age Unit"
+      );
+
+      return (
+        <TableRow key={index}>
+          <TableHeadCell>{ConvertToFriendlyNames(item.label)}</TableHeadCell>
+          {item.label === "Age" && age && (
+            <TableCell>
+              <span>
+                {item.value} {age}
+              </span>
+            </TableCell>
+          )}
+          {item.label === "Weight" && weight && (
+            <TableCell>
+              <span>
+                {item.value} {weight}
+              </span>
+            </TableCell>
+          )}
+          {item.label.indexOf("Weight") === -1 &&
+            item.label.indexOf("Age") === -1 && (
+              <TableCell>{item.value} </TableCell>
+            )}
+        </TableRow>
+      );
+    });
 
   return PetAttributeRows;
 };

--- a/src/pages/Pet.jsx
+++ b/src/pages/Pet.jsx
@@ -1,6 +1,7 @@
+import React, { useEffect } from "react";
+
 import PetDetail from "../components/PetDetail";
 import PetSidebar from "../components/PetSidebar";
-import React from "react";
 import ReactHtmlParser from "react-html-parser";
 import usePet from "../hooks/usePet";
 
@@ -8,6 +9,10 @@ const AdoptablePetsDetails = (props) => {
   const { animalId } = props.match.params;
   const petStatus = window.pets.petStatus;
   const [{ hasError, animal, isLoading }] = usePet(animalId, petStatus);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  });
 
   if (!animal) {
     return <p>Loading information for {animalId}...</p>;


### PR DESCRIPTION
There was an issue with Details pertaining persisting scroll position when a route changed. This reset the scroll position when you load pet details.

I also noticed that this was showing weight with no value, so I went ahead and updated age and weight so they would only show when they have a value.